### PR TITLE
reverse ordering of versions / skip resolving transitive dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /bin
 nb-configuration.xml
 nbactions.xml
+repository-connector.iml

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
 	<artifactId>repository-connector</artifactId>
 	<name>Repository Connector</name>
-	<version>1.1.1</version>
+	<version>1.1.2-SNAPSHOT</version>
 	<packaging>hpi</packaging>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
 	<artifactId>repository-connector</artifactId>
 	<name>Repository Connector</name>
-	<version>1.0.2-SNAPSHOT</version>
+	<version>1.1.0</version>
 	<packaging>hpi</packaging>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
 	<artifactId>repository-connector</artifactId>
 	<name>Repository Connector</name>
-	<version>1.1.0</version>
+	<version>1.1.1-SNAPSHOT</version>
 	<packaging>hpi</packaging>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
 	<artifactId>repository-connector</artifactId>
 	<name>Repository Connector</name>
-	<version>1.1.1-SNAPSHOT</version>
+	<version>1.1.1</version>
 	<packaging>hpi</packaging>
 
 	<properties>

--- a/src/main/java/org/jvnet/hudson/plugins/repositoryconnector/VersionParameterValue.java
+++ b/src/main/java/org/jvnet/hudson/plugins/repositoryconnector/VersionParameterValue.java
@@ -1,25 +1,22 @@
 package org.jvnet.hudson.plugins.repositoryconnector;
 
 import hudson.model.StringParameterValue;
-import java.util.logging.Level;
 
-import java.util.logging.Logger;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
  * This class sets the build parameter as environment value
- * "groupid.artifactid=version"
+ * "groupid.artifactid=version" or as "name=value".
  *
  * @author mrumpf
  *
  */
+@SuppressWarnings("serial")
 public class VersionParameterValue extends StringParameterValue {
-
-    private static final Logger log = Logger
-            .getLogger(VersionParameterValue.class.getName());
 
     private final String groupid;
     private final String artifactid;
+    private final String propertyName;
 
     public String getGroupid() {
         return groupid;
@@ -29,14 +26,16 @@ public class VersionParameterValue extends StringParameterValue {
         return artifactid;
     }
 
+    public String getPropertyName() {
+        return propertyName;
+    }
+
     @DataBoundConstructor
-    public VersionParameterValue(String groupid, String artifactid, String version) {
-        super(groupid + "." + artifactid, version);
-        if (log.isLoggable(Level.FINE)) {
-            log.fine("Creating environment build parameter 'groupid.artifactid=version'");
-        }
+    public VersionParameterValue(String groupid, String artifactid, String propertyName, String version) {
+        super((propertyName != null && !propertyName.isEmpty()) ? propertyName : groupid + "." + artifactid, version);
         this.groupid = groupid;
         this.artifactid = artifactid;
+        this.propertyName = propertyName;
     }
 
     public String toString() {
@@ -49,6 +48,8 @@ public class VersionParameterValue extends StringParameterValue {
         sb.append(groupid);
         sb.append(", artifactid=");
         sb.append(artifactid);
+        sb.append(", propertyName=");
+        sb.append(propertyName);
         sb.append(']');
         return sb.toString();
     }

--- a/src/main/java/org/jvnet/hudson/plugins/repositoryconnector/aether/Aether.java
+++ b/src/main/java/org/jvnet/hudson/plugins/repositoryconnector/aether/Aether.java
@@ -148,6 +148,9 @@ public class Aether {
 	}
 
 	public String convertHudsonNonProxyToJavaNonProxy(String hudsonNonProxy) {
+        if (StringUtils.isEmpty(hudsonNonProxy)) {
+            return "";
+        }
 		String[] nonProxyArray = hudsonNonProxy.split("[ \t\n,|]+");
 		String nonProxyOneLine = StringUtils.join(nonProxyArray, '|');
 		return nonProxyOneLine;

--- a/src/main/java/org/jvnet/hudson/plugins/repositoryconnector/aether/Aether.java
+++ b/src/main/java/org/jvnet/hudson/plugins/repositoryconnector/aether/Aether.java
@@ -116,13 +116,14 @@ public class Aether {
                 repoObj.setAuthentication(authentication);
             }
             repoObj.setRepositoryManager(repo.isRepositoryManager());
+            repoObj.setPolicy(true, snapshotPolicy);
+            repoObj.setPolicy(false, releasePolicy);
+            
             if (repoObj.isRepositoryManager()) {
                 // well, in case of repository manager, let's have a look one step deeper
                 // @see org.sonatype.aether.impl.internal.DefaultMetadataResolver#getEnabledSourceRepositories(org.sonatype.aether.repository.RemoteRepository, org.sonatype.aether.metadata.Metadata.Nature)
                 repoObj.setMirroredRepositories(resolveMirrors(repoObj));
             }
-            repoObj.setPolicy(true, snapshotPolicy);
-            repoObj.setPolicy(false, releasePolicy);
             repositories.add(repoObj);
         }
     }

--- a/src/main/java/org/jvnet/hudson/plugins/repositoryconnector/aether/Aether.java
+++ b/src/main/java/org/jvnet/hudson/plugins/repositoryconnector/aether/Aether.java
@@ -128,27 +128,21 @@ public class Aether {
     }
     
 	private void addProxySelectorIfNecessary(DefaultRepositorySystemSession repositorySession) {
-		Jenkins hudson = Jenkins.getInstance();
-		if (hudson.proxy != null && hudson.proxy.name != null
-				&& !hudson.proxy.name.isEmpty()) {
+		Jenkins jenkins = Jenkins.getInstance();
+		if (jenkins.proxy != null && StringUtils.isNotBlank(jenkins.proxy.name)) {
 			DefaultProxySelector proxySelector = new DefaultProxySelector();
-			Authentication authenticator = new Authentication(
-					hudson.proxy.getUserName(), hudson.proxy.getPassword());
+			Authentication authenticator = new Authentication(jenkins.proxy.getUserName(), jenkins.proxy.getPassword());
 
-			Proxy httpProxy = new Proxy("http", hudson.proxy.name,
-					hudson.proxy.port, authenticator);
-			Proxy httpsProxy = new Proxy("https", hudson.proxy.name,
-					hudson.proxy.port, authenticator);
+			Proxy httpProxy = new Proxy("http", jenkins.proxy.name, jenkins.proxy.port, authenticator);
+			Proxy httpsProxy = new Proxy("https", jenkins.proxy.name, jenkins.proxy.port, authenticator);
 
-			String nonProxySettings = convertHudsonNonProxyToJavaNonProxy(hudson.proxy.noProxyHost);
+			String nonProxySettings = convertHudsonNonProxyToJavaNonProxy(jenkins.proxy.noProxyHost);
 
 			proxySelector.add(httpProxy, nonProxySettings);
 			proxySelector.add(httpsProxy, nonProxySettings);
 
-			log.log(Level.FINE,
-					"Setting proxy for Aether: host={0}, port={1}, user={2}, password=******, nonProxyHosts={3}",
-					new Object[] { hudson.proxy.name, hudson.proxy.port,
-							hudson.proxy.getUserName(), nonProxySettings });
+			log.log(Level.FINE, "Setting proxy for Aether: host={0}, port={1}, user={2}, password=******, nonProxyHosts={3}",
+					new Object[] { jenkins.proxy.name, jenkins.proxy.port, jenkins.proxy.getUserName(), nonProxySettings });
 			repositorySession.setProxySelector(proxySelector);
 		}
 	}

--- a/src/main/resources/org/jvnet/hudson/plugins/repositoryconnector/VersionParameterDefinition/config.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/repositoryconnector/VersionParameterDefinition/config.jelly
@@ -9,6 +9,9 @@
             </j:forEach>
         </select>
     </f:entry>
+    <f:entry title="${%PropertyName}">
+        <f:textbox field="propertyName" value="${instance.propertyName}" />
+    </f:entry>
     <f:entry title="${%GroupId}">
         <f:textbox field="groupid" value="${instance.groupid}" />
     </f:entry>

--- a/src/main/resources/org/jvnet/hudson/plugins/repositoryconnector/VersionParameterDefinition/config.properties
+++ b/src/main/resources/org/jvnet/hudson/plugins/repositoryconnector/VersionParameterDefinition/config.properties
@@ -2,3 +2,4 @@ Repository=Repository
 GroupId=Group Id
 ArtifactId=Artifact Id
 Description=Description
+PropertyName=Property Name

--- a/src/main/resources/org/jvnet/hudson/plugins/repositoryconnector/VersionParameterDefinition/config_de.properties
+++ b/src/main/resources/org/jvnet/hudson/plugins/repositoryconnector/VersionParameterDefinition/config_de.properties
@@ -2,3 +2,4 @@ Repository=Verzeichnis
 GroupId=Gruppen Id
 ArtifactId=Artefakt Id
 Description=Beschreibung
+PropertyName=Attributname

--- a/src/test/java/org/jvnet/hudson/plugins/repositoryconnector/aether/AetherTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/repositoryconnector/aether/AetherTest.java
@@ -1,0 +1,36 @@
+package org.jvnet.hudson.plugins.repositoryconnector.aether;
+
+import hudson.model.Cause;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+import hudson.tasks.Shell;
+import org.apache.commons.io.FileUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.jvnet.hudson.plugins.repositoryconnector.Artifact;
+import org.jvnet.hudson.plugins.repositoryconnector.ArtifactResolver;
+
+import java.io.File;
+import java.io.PrintStream;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+
+public class AetherTest {
+
+    private Aether sut;
+
+    @Before
+    public void setup()
+    {
+        sut = new Aether( new File("jenkinstest"), System.out, false );
+    }
+
+    @Test
+    public void convertGivenNonHttpProxySettings() throws Exception {
+
+        String result = sut.convertHudsonNonProxyToJavaNonProxy("localhost\n*.google.com\n\napple.com");
+
+        assertEquals("New lines should be replaced", result, "localhost|*.google.com|apple.com");
+    }
+}

--- a/src/test/java/org/jvnet/hudson/plugins/repositoryconnector/aether/AetherTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/repositoryconnector/aether/AetherTest.java
@@ -1,18 +1,9 @@
 package org.jvnet.hudson.plugins.repositoryconnector.aether;
 
-import hudson.model.Cause;
-import hudson.model.FreeStyleProject;
-import hudson.model.Result;
-import hudson.tasks.Shell;
-import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.Test;
-import org.jvnet.hudson.plugins.repositoryconnector.Artifact;
-import org.jvnet.hudson.plugins.repositoryconnector.ArtifactResolver;
 
 import java.io.File;
-import java.io.PrintStream;
-import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
 
@@ -21,9 +12,8 @@ public class AetherTest {
     private Aether sut;
 
     @Before
-    public void setup()
-    {
-        sut = new Aether( new File("jenkinstest"), System.out, false );
+    public void setup() {
+        sut = new Aether(new File("jenkinstest"), System.out, false);
     }
 
     @Test
@@ -32,5 +22,10 @@ public class AetherTest {
         String result = sut.convertHudsonNonProxyToJavaNonProxy("localhost\n*.google.com\n\napple.com");
 
         assertEquals("New lines should be replaced", result, "localhost|*.google.com|apple.com");
+    }
+
+    @Test
+    public void convertGivenNullNonHttpProxySettings() throws Exception {
+        assertEquals("New lines should be replaced", sut.convertHudsonNonProxyToJavaNonProxy(null), "");
     }
 }


### PR DESCRIPTION
hi,

i just made some changes that i actually needed myself and i hope this might be useful for others. two things i changed:

**reverse order**

in most cases, the selection of versions with the *oldest* one first doesn't make much sense. i added a "reverseOrder" in the VersionParameterDefinition and added a bit of code to getChoices() to reverse the order.

**transitive dependencies**

the ArtifactResolver is supposed to download an artifact, right? it does that just fine, problem is that it was using "collectDependencies()" to download it, then skipped them. in our case, this didn't work because from where jenkins was running, not even the POMs of the transitive dependencies were accessible. i changed Aether to call "resolveArtifact()" instead of "collectDependencies()" ... this just downloads the given artifact and ignores any dependencies.

i made these changes based on the 1.1.1 tag, because the current dev branch was not compiling for me.


